### PR TITLE
fix(types): update type defs

### DIFF
--- a/packages/node/dist/types.d.ts
+++ b/packages/node/dist/types.d.ts
@@ -1,4 +1,4 @@
 declare module "@beam-australia/react-env" {
-    function env(key: string): string
+    function env(key?: string): string | undefined
     export = env
 }


### PR DESCRIPTION
This removes the typescript warnings which appear when no argument to `env` function is given and throws errors that the value could possibly undefined when the given key does not exist.